### PR TITLE
GCache2: Make Remove return an error

### DIFF
--- a/arc.go
+++ b/arc.go
@@ -202,13 +202,10 @@ func (c *ARC) Purge() {
 	return
 }
 
-func (c *ARC) Remove(key interface{}) bool {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
+func (c *ARC) remove(key interface{}) error {
 	elt, exists := c.store[key]
 	if !exists {
-		return false
+		return KeyNotFoundError
 	}
 
 	if elt.parent != nil {
@@ -217,7 +214,14 @@ func (c *ARC) Remove(key interface{}) bool {
 
 	delete(c.store, elt.key)
 	c.size--
-	return true
+	return nil
+}
+
+func (c *ARC) Remove(key interface{}) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.remove(key)
 }
 
 func (c *ARC) Len() int {

--- a/cache.go
+++ b/cache.go
@@ -23,7 +23,7 @@ type Cache interface {
 	GetIFPresent(interface{}) (interface{}, error)
 	GetALL() map[interface{}]interface{}
 	get(interface{}, bool) (interface{}, error)
-	Remove(interface{}) bool
+	Remove(interface{}) error
 	Purge()
 	Keys() []interface{}
 	Len() int

--- a/lfu.go
+++ b/lfu.go
@@ -227,19 +227,19 @@ func (c *LFUCache) evict(count int) {
 }
 
 // Removes the provided key from the cache.
-func (c *LFUCache) Remove(key interface{}) bool {
+func (c *LFUCache) Remove(key interface{}) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	return c.remove(key)
 }
 
-func (c *LFUCache) remove(key interface{}) bool {
+func (c *LFUCache) remove(key interface{}) error {
 	if item, ok := c.store[key]; ok {
 		c.removeItem(item)
-		return true
+		return nil
 	}
-	return false
+	return KeyNotFoundError
 }
 
 // removeElement is used to remove a given list element from the cache

--- a/lru.go
+++ b/lru.go
@@ -190,19 +190,19 @@ func (c *LRUCache) evict(count int) {
 }
 
 // Removes the provided key from the cache.
-func (c *LRUCache) Remove(key interface{}) bool {
+func (c *LRUCache) Remove(key interface{}) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	return c.remove(key)
 }
 
-func (c *LRUCache) remove(key interface{}) bool {
+func (c *LRUCache) remove(key interface{}) error {
 	if ent, ok := c.store[key]; ok {
 		c.removeElement(ent)
-		return true
+		return nil
 	}
-	return false
+	return KeyNotFoundError
 }
 
 func (c *LRUCache) removeElement(e *list.Element) {

--- a/simple.go
+++ b/simple.go
@@ -179,23 +179,23 @@ func (c *SimpleCache) evict(count int) {
 }
 
 // Removes the provided key from the cache.
-func (c *SimpleCache) Remove(key interface{}) bool {
+func (c *SimpleCache) Remove(key interface{}) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	return c.remove(key)
 }
 
-func (c *SimpleCache) remove(key interface{}) bool {
+func (c *SimpleCache) remove(key interface{}) error {
 	item, ok := c.store[key]
 	if ok {
 		delete(c.store, key)
 		if c.evictedFunc != nil {
 			c.evictedFunc(key, item.value)
 		}
-		return true
+		return nil
 	}
-	return false
+	return KeyNotFoundError
 }
 
 // Returns a slice of the keys in the cache.


### PR DESCRIPTION
This PR address issues:

- #19: GCache2: `cache.Remove` should return an error object

along with some stylistic changes. 