### PR TITLE
GCache2: Consistent locking policy and some refactors

### DIFF
--- a/arc.go
+++ b/arc.go
@@ -136,6 +136,13 @@ func (c *ARC) getWithLoader(key interface{}, isWait bool) (interface{}, error) {
 	return value, nil
 }
 
+func (c *ARC) unsafeGet(key interface{}, onLoad bool) (interface{}, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.get(key, onLoad)
+}
+
 func (c *ARC) Get(key interface{}) (interface{}, error) {
 	c.mu.Lock()
 	v, err := c.get(key, false)

--- a/cache.go
+++ b/cache.go
@@ -22,7 +22,7 @@ type Cache interface {
 	Get(interface{}) (interface{}, error)
 	GetIFPresent(interface{}) (interface{}, error)
 	GetALL() map[interface{}]interface{}
-	get(interface{}, bool) (interface{}, error)
+	unsafeGet(interface{}, bool) (interface{}, error)
 	Remove(interface{}) error
 	Purge()
 	Keys() []interface{}

--- a/lfu.go
+++ b/lfu.go
@@ -109,6 +109,13 @@ func (c *LFUCache) set(key, value interface{}) (interface{}, error) {
 	return item, nil
 }
 
+func (c *LFUCache) unsafeGet(key interface{}, onLoad bool) (interface{}, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.get(key, onLoad)
+}
+
 // Get a value from cache pool using key if it exists.
 // If it dose not exists key and has LoaderFunc,
 // generate a value using `LoaderFunc` method returns value.

--- a/lru.go
+++ b/lru.go
@@ -95,6 +95,13 @@ func (c *LRUCache) SetWithExpire(key, value interface{}, expiration time.Duratio
 	return nil
 }
 
+func (c *LRUCache) unsafeGet(key interface{}, onLoad bool) (interface{}, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.get(key, onLoad)
+}
+
 // Get a value from cache pool using key if it exists.
 // If it dose not exists key and has LoaderFunc,
 // generate a value using `LoaderFunc` method returns value.

--- a/simple.go
+++ b/simple.go
@@ -84,6 +84,13 @@ func (c *SimpleCache) set(key, value interface{}) (interface{}, error) {
 	return item, nil
 }
 
+func (c *SimpleCache) unsafeGet(key interface{}, onLoad bool) (interface{}, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.get(key, onLoad)
+}
+
 // Get a value from cache pool using key if it exists.
 // If it dose not exists key and has LoaderFunc,
 // generate a value using `LoaderFunc` method returns value.

--- a/singleflight.go
+++ b/singleflight.go
@@ -42,7 +42,7 @@ type Group struct {
 // original to complete and receives the same results.
 func (g *Group) Do(key interface{}, fn func() (interface{}, error), isWait bool) (interface{}, bool, error) {
 	g.mu.Lock()
-	v, err := g.cache.get(key, true)
+	v, err := g.cache.unsafeGet(key, true)
 	if err == nil {
 		g.mu.Unlock()
 		return v, false, nil


### PR DESCRIPTION
This PR addresses issues:
- #17 "GCache2: Have a consistent mutex locking policy"
- And partially: #28 "GCache2: Harmonize code organization"

For now, we still have to redundantly expose `cache.unsafeGet` since `gcache2/singleflight` use it when solving concurrency conflicts for `loader` functions. I'm not too fond of that approach for obvious reasons (redundant, poor aesthetics) but for now it's OK. I renamed `cache.get` to `cache.unsafeGet` to discourage its use.